### PR TITLE
Added flight tweet blocker

### DIFF
--- a/Mute Filters for Tweetbot.md
+++ b/Mute Filters for Tweetbot.md
@@ -36,6 +36,8 @@ Annoyances
 
 * (@.*){5} - mute all tweets containing more than 5 @ mentions.
 
+* `(?i)[A-Z][A-Z][A-Z] \u2708\ufe0f [A-Z][A-Z][A-Z]` - Tweeting a flight: LHR ✈️ SFO
+
 Stating the obvious
 ----------
 * `(?i)((new|change).*avatar)|(avatar.*(new|change))` - *"Look, I changed my avatar"*


### PR DESCRIPTION
Some people like to tell the world when they board a plane, just stating departure and arrival airport code. I'm not as excited about airplanes as they seem to be.
